### PR TITLE
5: Modified back button to prevent disappearing

### DIFF
--- a/ParkenDD/LotlistView/LotlistViewController.swift
+++ b/ParkenDD/LotlistView/LotlistViewController.swift
@@ -17,18 +17,18 @@ class LotlistViewController: UITableViewController, UIViewControllerPreviewingDe
 
 	var dataURL: String?
 
-    var dataSource = LotlistDataSource()
+	var dataSource = LotlistDataSource()
 
 	@IBOutlet weak var titleButton: UIButton!
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
 
-        tableView.dataSource = dataSource
+		tableView.dataSource = dataSource
 
-        Location.shared.onMove { [weak self] location in
-            self?.tableView.reloadData()
-        }
+		Location.shared.onMove { [weak self] location in
+			self?.tableView.reloadData()
+		}
 
 		// display the standard reload button
 		showReloadButton()
@@ -37,9 +37,9 @@ class LotlistViewController: UITableViewController, UIViewControllerPreviewingDe
 		let navBar = self.navigationController?.navigationBar
 		navBar!.isTranslucent = false
 		navBar!.tintColor = UIColor.black
-        
-        // set back button text when navigating to next screen.
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: L10n.back.string, style: .plain, target: nil, action: nil)
+
+		// set back button text when navigating to next screen.
+		navigationItem.backBarButtonItem = UIBarButtonItem(title: L10n.back.string, style: .plain, target: nil, action: nil)
 
 		// Set title to selected city
 		updateTitle(withCity: nil)
@@ -61,7 +61,7 @@ class LotlistViewController: UITableViewController, UIViewControllerPreviewingDe
 		// Start getting location updates if the user wants lots sorted by distance
 		if let sortingType = UserDefaults.standard.string(forKey: Defaults.sortingType), sortingType == Sorting.distance || sortingType == Sorting.euclid {
 			if Location.authState == .authorizedWhenInUse {
-                Location.manager.startUpdatingLocation()
+				Location.manager.startUpdatingLocation()
 			} else {
 				let alertController = UIAlertController(title: L10n.locationDataErrorTitle.string, message: L10n.locationDataError.string, preferredStyle: UIAlertControllerStyle.alert)
 				alertController.addAction(UIAlertAction(title: L10n.cancel.string, style: UIAlertActionStyle.cancel, handler: nil))
@@ -75,7 +75,7 @@ class LotlistViewController: UITableViewController, UIViewControllerPreviewingDe
 			Location.manager.stopUpdatingLocation()
 		}
 
-        (tableView.dataSource as? LotlistDataSource)?.sortLots()
+		(tableView.dataSource as? LotlistDataSource)?.sortLots()
 
 		refreshControl?.endRefreshing()
 	}
@@ -101,68 +101,68 @@ class LotlistViewController: UITableViewController, UIViewControllerPreviewingDe
 		// Set title to selected city
 		updateTitle(withCity: nil)
 
-        guard let selectedCity = UserDefaults.standard.string(forKey: Defaults.selectedCity),
-            let sortingType = UserDefaults.standard.string(forKey: Defaults.sortingType) else {
-            return
-        }
+		guard let selectedCity = UserDefaults.standard.string(forKey: Defaults.selectedCity),
+			  let sortingType = UserDefaults.standard.string(forKey: Defaults.sortingType) else {
+			return
+		}
 
-        park.fetchLots(forCity: selectedCity) { [weak self] result in
-            switch result {
-            case .failure(let error):
-                self?.stopRefreshUI()
-                self?.handleUpdateError(error)
-            case .success(let response):
-                self?.stopRefreshUI()
-                self?.showOutdatedDataWarning(lastUpdated: response.lastUpdated, lastDownloaded: response.lastDownloaded)
-                DispatchQueue.main.async {
-                    (self?.tableView.dataSource as? LotlistDataSource)?.set(lots: response.lots)
-                    self?.parkinglots = response.lots
-                    self?.tableView.reloadData()
-                }
-            }
-        }
+		park.fetchLots(forCity: selectedCity) { [weak self] result in
+			switch result {
+			case .failure(let error):
+				self?.stopRefreshUI()
+				self?.handleUpdateError(error)
+			case .success(let response):
+				self?.stopRefreshUI()
+				self?.showOutdatedDataWarning(lastUpdated: response.lastUpdated, lastDownloaded: response.lastDownloaded)
+				DispatchQueue.main.async {
+					(self?.tableView.dataSource as? LotlistDataSource)?.set(lots: response.lots)
+					self?.parkinglots = response.lots
+					self?.tableView.reloadData()
+				}
+			}
+		}
 	}
 
-    func showOutdatedDataWarning(lastUpdated: Date, lastDownloaded: Date) {
-        // TODO: Use both dates to give a diff to the user or show that the server seems to be broken.
-        let now = Date()
-        let calendar = Calendar(identifier: .gregorian)
-        let dateDiff = calendar.dateComponents(Set([.minute]), from: lastUpdated, to: now)
+	func showOutdatedDataWarning(lastUpdated: Date, lastDownloaded: Date) {
+		// TODO: Use both dates to give a diff to the user or show that the server seems to be broken.
+		let now = Date()
+		let calendar = Calendar(identifier: .gregorian)
+		let dateDiff = calendar.dateComponents(Set([.minute]), from: lastUpdated, to: now)
 
-        var attrs = [NSAttributedStringKey: Any]()
+		var attrs = [NSAttributedStringKey: Any]()
 
-        if let diff = dateDiff.minute, diff >= 60 {
-            attrs = [NSAttributedStringKey.foregroundColor: UIColor.red]
-            drop(L10n.outdatedDataWarning.string, state: .blur(.dark))
-        }
+		if let diff = dateDiff.minute, diff >= 60 {
+			attrs = [NSAttributedStringKey.foregroundColor: UIColor.red]
+			drop(L10n.outdatedDataWarning.string, state: .blur(.dark))
+		}
 
-        let dateFormatter = DateFormatter(dateFormat: "dd.MM.yyyy HH:mm", timezone: nil)
-        DispatchQueue.main.async {
-            self.refreshControl?.attributedTitle = NSAttributedString(string: "\(L10n.lastUpdated(dateFormatter.string(from: lastUpdated)))", attributes: attrs)
-        }
-    }
+		let dateFormatter = DateFormatter(dateFormat: "dd.MM.yyyy HH:mm", timezone: nil)
+		DispatchQueue.main.async {
+			self.refreshControl?.attributedTitle = NSAttributedString(string: "\(L10n.lastUpdated(dateFormatter.string(from: lastUpdated)))", attributes: attrs)
+		}
+	}
 
 	/**
 	Called by the request to the API in case of failure and handed the error to display to the user.
 	*/
 	func handleUpdateError(_ err: Error) {
-        let description = err.localizedDescription
-        drop(description, state: .error)
-//        switch err {
-//        case .server(_), .decoding:
-//            drop(L10n.serverError.string, state: .error)
-//        case .request:
-//            drop(L10n.requestError.string, state: .error)
-//            // TODO: Is this really a good idea?
-////        case .notFound:
-////            UserDefaults.standard.set("Dresden", forKey: Defaults.selectedCity)
-////            UserDefaults.standard.set("Dresden", forKey: Defaults.selectedCityName)
-////            UserDefaults.standard.synchronize()
-////            updateData()
-////            updateTitle(withCity: "Dresden")
-//        default:
-//            drop(L10n.unknownError.string, state: .error)
-//        }
+		let description = err.localizedDescription
+		drop(description, state: .error)
+		//        switch err {
+		//        case .server(_), .decoding:
+		//            drop(L10n.serverError.string, state: .error)
+		//        case .request:
+		//            drop(L10n.requestError.string, state: .error)
+		//            // TODO: Is this really a good idea?
+		////        case .notFound:
+		////            UserDefaults.standard.set("Dresden", forKey: Defaults.selectedCity)
+		////            UserDefaults.standard.set("Dresden", forKey: Defaults.selectedCityName)
+		////            UserDefaults.standard.synchronize()
+		////            updateData()
+		////            updateTitle(withCity: "Dresden")
+		//        default:
+		//            drop(L10n.unknownError.string, state: .error)
+		//        }
 	}
 	
 	func updateTitle(withCity city: String?) {
@@ -181,8 +181,8 @@ class LotlistViewController: UITableViewController, UIViewControllerPreviewingDe
 	@IBAction func titleButtonTapped(_ sender: UIButton) {
 		let settingsStoryBoard = UIStoryboard(name: "Settings", bundle: Bundle.main)
 		let citySelectionVC = settingsStoryBoard.instantiateViewController(withIdentifier: "City SelectionTVC")
-        citySelectionVC.modalPresentationStyle = .popover
-//        self.present(citySelectionVC, animated: true, completion: nil)
+		citySelectionVC.modalPresentationStyle = .popover
+		//        self.present(citySelectionVC, animated: true, completion: nil)
 		show(citySelectionVC, sender: self)
 	}
 	
@@ -235,11 +235,11 @@ class LotlistViewController: UITableViewController, UIViewControllerPreviewingDe
 	// /////////////////////////////////////////////////////////////////////////
 
 	override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 60
+		return 60
 	}
 
 	override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = (tableView.dequeueReusableCell(withIdentifier: String(describing: LotCell.self)) as? LotCell) ?? LotCell()
+		let cell = (tableView.dequeueReusableCell(withIdentifier: String(describing: LotCell.self)) as? LotCell) ?? LotCell()
 		
 		let thisLot = parkinglots[indexPath.row]
 		cell.setParkinglot(thisLot)
@@ -272,22 +272,22 @@ class LotlistViewController: UITableViewController, UIViewControllerPreviewingDe
 	// /////////////////////////////////////////////////////////////////////////
 	
 	func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
-//		let fullForecastVC = ForecastViewController()
-//		fullForecastVC.lot = (viewControllerToCommit as? MiniForecastViewController)?.lot
-//		show(fullForecastVC, sender: nil)
+		//		let fullForecastVC = ForecastViewController()
+		//		fullForecastVC.lot = (viewControllerToCommit as? MiniForecastViewController)?.lot
+		//		show(fullForecastVC, sender: nil)
 	}
 	
 	func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
-//		if let indexPath = tableView.indexPathForRow(at: location) {
-//			guard let hasForecast = (tableView.cellForRow(at: indexPath) as? LotCell)?.parkinglot?.hasForecast, hasForecast else { return nil }
-//			
-//			if #available(iOS 9.0, *) {
-//			    previewingContext.sourceRect = tableView.rectForRow(at: indexPath)
-//			}
-//			let forecastVC = MiniForecastViewController()
-//			forecastVC.lot = parkinglots[indexPath.row]
-//			return forecastVC
-//		}
+		//		if let indexPath = tableView.indexPathForRow(at: location) {
+		//			guard let hasForecast = (tableView.cellForRow(at: indexPath) as? LotCell)?.parkinglot?.hasForecast, hasForecast else { return nil }
+		//
+		//			if #available(iOS 9.0, *) {
+		//			    previewingContext.sourceRect = tableView.rectForRow(at: indexPath)
+		//			}
+		//			let forecastVC = MiniForecastViewController()
+		//			forecastVC.lot = parkinglots[indexPath.row]
+		//			return forecastVC
+		//		}
 		return nil
 	}
 

--- a/ParkenDD/LotlistView/LotlistViewController.swift
+++ b/ParkenDD/LotlistView/LotlistViewController.swift
@@ -38,6 +38,7 @@ class LotlistViewController: UITableViewController, UIViewControllerPreviewingDe
 		navBar!.isTranslucent = false
 		navBar!.tintColor = UIColor.black
         
+        // set back button text when navigating to next screen.
         navigationItem.backBarButtonItem = UIBarButtonItem(title: L10n.back.string, style: .plain, target: nil, action: nil)
 
 		// Set title to selected city

--- a/ParkenDD/LotlistView/LotlistViewController.swift
+++ b/ParkenDD/LotlistView/LotlistViewController.swift
@@ -37,6 +37,8 @@ class LotlistViewController: UITableViewController, UIViewControllerPreviewingDe
 		let navBar = self.navigationController?.navigationBar
 		navBar!.isTranslucent = false
 		navBar!.tintColor = UIColor.black
+        
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: L10n.done.string, style: .plain, target: nil, action: nil)
 
 		// Set title to selected city
 		updateTitle(withCity: nil)

--- a/ParkenDD/LotlistView/LotlistViewController.swift
+++ b/ParkenDD/LotlistView/LotlistViewController.swift
@@ -38,7 +38,7 @@ class LotlistViewController: UITableViewController, UIViewControllerPreviewingDe
 		navBar!.isTranslucent = false
 		navBar!.tintColor = UIColor.black
         
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: L10n.done.string, style: .plain, target: nil, action: nil)
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: L10n.back.string, style: .plain, target: nil, action: nil)
 
 		// Set title to selected city
 		updateTitle(withCity: nil)

--- a/ParkenDD/LotlistView/LotlistViewController.swift
+++ b/ParkenDD/LotlistView/LotlistViewController.swift
@@ -178,6 +178,8 @@ class LotlistViewController: UITableViewController, UIViewControllerPreviewingDe
 	@IBAction func titleButtonTapped(_ sender: UIButton) {
 		let settingsStoryBoard = UIStoryboard(name: "Settings", bundle: Bundle.main)
 		let citySelectionVC = settingsStoryBoard.instantiateViewController(withIdentifier: "City SelectionTVC")
+        citySelectionVC.modalPresentationStyle = .popover
+//        self.present(citySelectionVC, animated: true, completion: nil)
 		show(citySelectionVC, sender: self)
 	}
 	

--- a/ParkenDD/SettingsView/CitySelectionTVC.swift
+++ b/ParkenDD/SettingsView/CitySelectionTVC.swift
@@ -16,6 +16,9 @@ class CitySelectionTVC: UITableViewController {
 	override func viewDidLoad() {
 		super.viewDidLoad()
 
+        self.navigationController?.navigationBar.isHidden = false
+        self.title = "Hey"
+
         park.fetchCities { [weak self] result in
             guard let response = try? result.get() else {
                 print(result)
@@ -30,7 +33,7 @@ class CitySelectionTVC: UITableViewController {
             }
         }
 	}
-
+    
 	// MARK: - Table view data source
 
 	override func numberOfSections(in tableView: UITableView) -> Int {

--- a/ParkenDD/SettingsView/CitySelectionTVC.swift
+++ b/ParkenDD/SettingsView/CitySelectionTVC.swift
@@ -10,70 +10,70 @@ import UIKit
 import ParkKit
 
 class CitySelectionTVC: UITableViewController {
-
-    var availableCities = [City]()
-
+	
+	var availableCities = [City]()
+	
 	override func viewDidLoad() {
 		super.viewDidLoad()
-
-        park.fetchCities { [weak self] result in
-            guard let response = try? result.get() else {
-                print(result)
-                return
-            }
-
-            let showExperimental = UserDefaults.standard.bool(forKey: Defaults.showExperimentalCities)
-            self?.availableCities = showExperimental ? response.cities : response.cities.filter { $0.hasActiveSupport }
-
-            OperationQueue.main.addOperation {
-                self?.tableView.reloadData()
-            }
-        }
+		
+		park.fetchCities { [weak self] result in
+			guard let response = try? result.get() else {
+				print(result)
+				return
+			}
+			
+			let showExperimental = UserDefaults.standard.bool(forKey: Defaults.showExperimentalCities)
+			self?.availableCities = showExperimental ? response.cities : response.cities.filter { $0.hasActiveSupport }
+			
+			OperationQueue.main.addOperation {
+				self?.tableView.reloadData()
+			}
+		}
 	}
-    
+	
 	// MARK: - Table view data source
-
+	
 	override func numberOfSections(in tableView: UITableView) -> Int {
 		return 1
 	}
-
+	
 	override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return availableCities.count
+		return availableCities.count
 	}
-
+	
 	override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
 		let cell = tableView.dequeueReusableCell(withIdentifier: "citySelectionCell", for: indexPath)
-        let selectedCity = UserDefaults.standard.string(forKey: Defaults.selectedCity) ?? ""
-
-        let city = availableCities[indexPath.row]
-
-        cell.textLabel?.text = city.name
-        cell.textLabel?.textColor = city.hasActiveSupport ? .black : .lightGray
+		let selectedCity = UserDefaults.standard.string(forKey: Defaults.selectedCity) ?? ""
+		
+		let city = availableCities[indexPath.row]
+		
+		cell.textLabel?.text = city.name
+		cell.textLabel?.textColor = city.hasActiveSupport ? .black : .lightGray
 		cell.accessoryType = city.name == selectedCity ? .checkmark : .none
-
+		
 		return cell
 	}
-
+	
 	// MARK: - Table view delegate
-
+	
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 		for row in 0..<tableView.numberOfRows(inSection: 0) {
 			tableView.cellForRow(at: IndexPath(row: row, section: 0))?.accessoryType = UITableViewCellAccessoryType.none
 		}
 		tableView.cellForRow(at: indexPath)?.accessoryType = UITableViewCellAccessoryType.checkmark
 		tableView.deselectRow(at: indexPath, animated: true)
-
-        let selectedCity = availableCities[indexPath.row]
-
-        UserDefaults.standard.set(selectedCity.name, forKey: Defaults.selectedCity)
-        UserDefaults.standard.set(selectedCity.name, forKey: Defaults.selectedCityName)
+		
+		let selectedCity = availableCities[indexPath.row]
+		
+		UserDefaults.standard.set(selectedCity.name, forKey: Defaults.selectedCity)
+		UserDefaults.standard.set(selectedCity.name, forKey: Defaults.selectedCityName)
 		UserDefaults.standard.synchronize()
-
+		
 		if let lotlistVC = UIApplication.shared.keyWindow?.rootViewController?.childViewControllers[0] as? LotlistViewController {
 			lotlistVC.updateData()
 		}
-
+		
 		let _ = navigationController?.popToRootViewController(animated: true)
 	}
-
+	
 }

--- a/ParkenDD/SettingsView/CitySelectionTVC.swift
+++ b/ParkenDD/SettingsView/CitySelectionTVC.swift
@@ -16,9 +16,6 @@ class CitySelectionTVC: UITableViewController {
 	override func viewDidLoad() {
 		super.viewDidLoad()
 
-        self.navigationController?.navigationBar.isHidden = false
-        self.title = "Hey"
-
         park.fetchCities { [weak self] result in
             guard let response = try? result.get() else {
                 print(result)

--- a/ParkenDD/SettingsView/CitySelectionTVC.swift
+++ b/ParkenDD/SettingsView/CitySelectionTVC.swift
@@ -16,6 +16,11 @@ class CitySelectionTVC: UITableViewController {
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		
+		// pretty navbar with black buttons
+		let navBar = self.navigationController?.navigationBar
+		navBar!.isTranslucent = false
+		navBar!.tintColor = UIColor.black
+		
 		park.fetchCities { [weak self] result in
 			guard let response = try? result.get() else {
 				print(result)

--- a/ParkenDD/SettingsView/SettingsViewController.swift
+++ b/ParkenDD/SettingsView/SettingsViewController.swift
@@ -26,6 +26,8 @@ class SettingsViewController: UITableViewController, MFMailComposeViewController
 
 		let doneButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(SettingsViewController.dismiss as (SettingsViewController) -> () -> ()))
 		self.navigationItem.rightBarButtonItem = doneButton
+        
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: L10n.settings.string, style: .plain, target: nil, action: nil)
 
 		self.navigationItem.title = L10n.settings.string
 		let font = UIFont(name: "AvenirNext-Medium", size: 18.0)

--- a/ParkenDD/SettingsView/SettingsViewController.swift
+++ b/ParkenDD/SettingsView/SettingsViewController.swift
@@ -20,37 +20,37 @@ enum Sections: Int {
 }
 
 class SettingsViewController: UITableViewController, MFMailComposeViewControllerDelegate {
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
+	
+	override func viewDidLoad() {
+		super.viewDidLoad()
+		
 		let doneButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(SettingsViewController.dismiss as (SettingsViewController) -> () -> ()))
 		self.navigationItem.rightBarButtonItem = doneButton
-        
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: L10n.settings.string, style: .plain, target: nil, action: nil)
-
+		
+		navigationItem.backBarButtonItem = UIBarButtonItem(title: L10n.settings.string, style: .plain, target: nil, action: nil)
+		
 		self.navigationItem.title = L10n.settings.string
 		let font = UIFont(name: "AvenirNext-Medium", size: 18.0)
 		var attrsDict = [NSAttributedStringKey: Any]()
 		attrsDict[NSAttributedStringKey.font] = font
 		self.navigationController?.navigationBar.titleTextAttributes = attrsDict
-    }
-
+	}
+	
 	@objc func dismiss() {
 		self.dismiss(animated: true, completion: nil)
 	}
-
+	
 	override func viewWillAppear(_ animated: Bool) {
 		tableView.reloadData()
 	}
-
-    // MARK: - Table view data source
-
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return 4
-    }
-
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+	
+	// MARK: - Table view data source
+	
+	override func numberOfSections(in tableView: UITableView) -> Int {
+		return 4
+	}
+	
+	override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
 		let sec = Sections(rawValue: section)!
 		switch sec {
 		case .cityOptions:
@@ -62,8 +62,8 @@ class SettingsViewController: UITableViewController, MFMailComposeViewController
 		case .otherOptions:
 			return 4
 		}
-    }
-
+	}
+	
 	override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
 		let sec = Sections(rawValue: section)!
 		switch sec {
@@ -77,23 +77,23 @@ class SettingsViewController: UITableViewController, MFMailComposeViewController
 			return L10n.otherOptions.string
 		}
 	}
-
+	
 	override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
 		let sec = Sections(rawValue: indexPath.section)!
 		let cell: UITableViewCell = UITableViewCell()
-
+		
 		let selectedCity = UserDefaults.standard.string(forKey: Defaults.selectedCityName)
 		let sortingType = UserDefaults.standard.string(forKey: Defaults.sortingType)
 		let doHideLots = UserDefaults.standard.bool(forKey: Defaults.skipNodataLots)
 		let useGrayscale = UserDefaults.standard.bool(forKey: Defaults.grayscaleUI)
-        let showExperimentalCities = UserDefaults.standard.bool(forKey: Defaults.showExperimentalCities)
-
+		let showExperimentalCities = UserDefaults.standard.bool(forKey: Defaults.showExperimentalCities)
+		
 		switch (sec, indexPath.row) {
 		// CITY OPTIONS
 		case (.cityOptions, 0):
 			cell.textLabel!.text = selectedCity
 			cell.accessoryType = UITableViewCellAccessoryType.disclosureIndicator
-
+			
 		// SORTING OPTIONS
 		case (.sortingOptions, 0):
 			cell.textLabel?.text = L10n.sortingtypeDefault.string
@@ -110,7 +110,7 @@ class SettingsViewController: UITableViewController, MFMailComposeViewController
 		case (.sortingOptions, 4):
 			cell.textLabel!.text = L10n.sortingtypeEuklid.string
 			cell.accessoryType = sortingType == Sorting.euclid ? UITableViewCellAccessoryType.checkmark : UITableViewCellAccessoryType.none
-
+			
 		// DISPLAY OPTIONS
 		case (.displayOptions, 0):
 			cell.textLabel?.text = L10n.hideNodataLots.string
@@ -118,10 +118,10 @@ class SettingsViewController: UITableViewController, MFMailComposeViewController
 		case (.displayOptions, 1):
 			cell.textLabel?.text = L10n.useGrayscaleColors.string
 			cell.accessoryType = useGrayscale ? UITableViewCellAccessoryType.checkmark : UITableViewCellAccessoryType.none
-        case (.displayOptions, 2):
-            cell.textLabel?.text = L10n.showexperimentalcitiessetting.string
-            cell.accessoryType = showExperimentalCities ? UITableViewCellAccessoryType.checkmark : UITableViewCellAccessoryType.none
-
+		case (.displayOptions, 2):
+			cell.textLabel?.text = L10n.showexperimentalcitiessetting.string
+			cell.accessoryType = showExperimentalCities ? UITableViewCellAccessoryType.checkmark : UITableViewCellAccessoryType.none
+			
 		// OTHER OPTIONS
 		case (.otherOptions, 0):
 			cell.textLabel?.text = L10n.aboutButton.string
@@ -135,29 +135,29 @@ class SettingsViewController: UITableViewController, MFMailComposeViewController
 		case (.otherOptions, 3):
 			cell.textLabel?.text = L10n.requestNewCity.string
 			cell.accessoryType = UITableViewCellAccessoryType.disclosureIndicator
-
+			
 		default:
 			break
 		}
-
+		
 		cell.textLabel?.font = UIFont(name: "AvenirNext-Regular", size: 16.0)
 		return cell
-
+		
 	}
-
+	
 	// MARK: - Table View Delegate
-
+	
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 		let sec = Sections(rawValue: indexPath.section)!
-
+		
 		switch sec {
 		// CITY OPTIONS
 		case .cityOptions:
 			performSegue(withIdentifier: "showCitySelection", sender: self)
-
+			
 		// SORTING OPTIONS
 		case .sortingOptions:
-
+			
 			// Don't let the user select a location based sorting option if the required authorization is missing
 			if indexPath.row == 1 || indexPath.row == 4 {
 				if Location.authState != .authorizedWhenInUse {
@@ -168,17 +168,17 @@ class SettingsViewController: UITableViewController, MFMailComposeViewController
 						UIApplication.shared.openURL(URL(string: UIApplicationOpenSettingsURLString)!)
 					}))
 					present(alertController, animated: true, completion: nil)
-
+					
 					tableView.deselectRow(at: indexPath, animated: true)
 					return
 				}
 			}
-
+			
 			for row in 0...4 {
 				tableView.cellForRow(at: IndexPath(row: row, section: Sections.sortingOptions.rawValue))?.accessoryType = UITableViewCellAccessoryType.none
 			}
 			tableView.cellForRow(at: indexPath)?.accessoryType = UITableViewCellAccessoryType.checkmark
-
+			
 			var defaultsValue: String
 			switch indexPath.row {
 			case 1:
@@ -193,7 +193,7 @@ class SettingsViewController: UITableViewController, MFMailComposeViewController
 				defaultsValue = Sorting.standard
 			}
 			UserDefaults.standard.setValue(defaultsValue, forKey: Defaults.sortingType)
-
+			
 		// DISPLAY OPTIONS
 		case .displayOptions:
 			switch indexPath.row {
@@ -216,34 +216,34 @@ class SettingsViewController: UITableViewController, MFMailComposeViewController
 					UserDefaults.standard.set(true, forKey: Defaults.grayscaleUI)
 					tableView.cellForRow(at: indexPath)?.accessoryType = UITableViewCellAccessoryType.checkmark
 				}
-            case 2:
-                let showExperimentalCities = UserDefaults.standard.bool(forKey: Defaults.showExperimentalCities)
-                if showExperimentalCities {
-                    UserDefaults.standard.set(false, forKey: Defaults.showExperimentalCities)
-                    tableView.cellForRow(at: indexPath)?.accessoryType = UITableViewCellAccessoryType.none
-                    refreshLotlist()
-                } else {
-                    let alert = UIAlertController(title: L10n.noteTitle.string, message: L10n.showexperimentalcitiesalert.string, preferredStyle: UIAlertControllerStyle.alert)
-                    alert.addAction(UIAlertAction(title: L10n.cancel.string, style: UIAlertActionStyle.cancel, handler: { (action) -> Void in
-
-                    }))
-                    alert.addAction(UIAlertAction(title: L10n.activate.string, style: UIAlertActionStyle.default, handler: { (action) -> Void in
-                        UserDefaults.standard.set(true, forKey: Defaults.showExperimentalCities)
-                        tableView.cellForRow(at: indexPath)?.accessoryType = UITableViewCellAccessoryType.checkmark
-                        refreshLotlist()
-                    }))
-                    present(alert, animated: true, completion: nil)
-                }
+			case 2:
+				let showExperimentalCities = UserDefaults.standard.bool(forKey: Defaults.showExperimentalCities)
+				if showExperimentalCities {
+					UserDefaults.standard.set(false, forKey: Defaults.showExperimentalCities)
+					tableView.cellForRow(at: indexPath)?.accessoryType = UITableViewCellAccessoryType.none
+					refreshLotlist()
+				} else {
+					let alert = UIAlertController(title: L10n.noteTitle.string, message: L10n.showexperimentalcitiesalert.string, preferredStyle: UIAlertControllerStyle.alert)
+					alert.addAction(UIAlertAction(title: L10n.cancel.string, style: UIAlertActionStyle.cancel, handler: { (action) -> Void in
+						
+					}))
+					alert.addAction(UIAlertAction(title: L10n.activate.string, style: UIAlertActionStyle.default, handler: { (action) -> Void in
+						UserDefaults.standard.set(true, forKey: Defaults.showExperimentalCities)
+						tableView.cellForRow(at: indexPath)?.accessoryType = UITableViewCellAccessoryType.checkmark
+						refreshLotlist()
+					}))
+					present(alert, animated: true, completion: nil)
+				}
 			default:
 				break
 			}
-
+			
 		// OTHER OPTIONS
 		case .otherOptions:
 			switch indexPath.row {
 			case 0:
 				if #available(iOS 9.0, *) {
-				    let safariVC = SFSafariViewController(url: URL(string: "http://parkendd.kilian.io/about.html")!, entersReaderIfAvailable: true)
+					let safariVC = SFSafariViewController(url: URL(string: "http://parkendd.kilian.io/about.html")!, entersReaderIfAvailable: true)
 					present(safariVC, animated: true, completion: nil)
 				} else {
 					UIApplication.shared.openURL(URL(string: "http://parkendd.kilian.io/about.html")!)
@@ -258,12 +258,12 @@ class SettingsViewController: UITableViewController, MFMailComposeViewController
 				if MFMailComposeViewController.canSendMail() {
 					let mail = MFMailComposeViewController()
 					mail.mailComposeDelegate = self
-
+					
 					let versionNumber = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-                    let buildNumber = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+					let buildNumber = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
 					mail.setSubject("[ParkenDD v\(versionNumber!) (\(buildNumber!))] Feedback")
 					mail.setToRecipients(["parkendd@kilian.io"])
-
+					
 					self.present(mail, animated: true, completion: nil)
 				}
 			case 3:
@@ -277,20 +277,20 @@ class SettingsViewController: UITableViewController, MFMailComposeViewController
 				break
 			}
 		}
-
+		
 		tableView.deselectRow(at: indexPath, animated: true)
 	}
-
+	
 	// MARK: - MFMailComposeViewControllerDelegate
-
+	
 	func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
 		self.dismiss(animated: true, completion: nil)
 	}
-
+	
 }
 
 func refreshLotlist() -> Void {
-    if let lotlistVC = UIApplication.shared.keyWindow?.rootViewController?.childViewControllers[0] as? LotlistViewController {
-        lotlistVC.updateData()
-    }
+	if let lotlistVC = UIApplication.shared.keyWindow?.rootViewController?.childViewControllers[0] as? LotlistViewController {
+		lotlistVC.updateData()
+	}
 }

--- a/ParkenDD/Supporting Files/Base.lproj/Localizable.strings
+++ b/ParkenDD/Supporting Files/Base.lproj/Localizable.strings
@@ -27,7 +27,7 @@
 "LOCATION_DATA_ERROR" = "ParkenDD is unable to get location data. Please allow it to do so in the system settings.";
 "CANCEL" = "Cancel";
 "SETTINGS" = "Settings";
-"DONE" = "Done";
+"BACK" = "Back";
 "CIRCA_SPOTS_AVAILABLE" = "ca. %@ spots available";
 "DISPLAY_OPTIONS" = "Display";
 "HIDE_NODATA_LOTS" = "Hide Lots Without Data";

--- a/ParkenDD/Supporting Files/Base.lproj/Localizable.strings
+++ b/ParkenDD/Supporting Files/Base.lproj/Localizable.strings
@@ -27,6 +27,7 @@
 "LOCATION_DATA_ERROR" = "ParkenDD is unable to get location data. Please allow it to do so in the system settings.";
 "CANCEL" = "Cancel";
 "SETTINGS" = "Settings";
+"DONE" = "Done";
 "CIRCA_SPOTS_AVAILABLE" = "ca. %@ spots available";
 "DISPLAY_OPTIONS" = "Display";
 "HIDE_NODATA_LOTS" = "Hide Lots Without Data";

--- a/ParkenDD/Supporting Files/Loc.swift
+++ b/ParkenDD/Supporting Files/Loc.swift
@@ -23,6 +23,7 @@ enum L10n {
   case closed
   /// Display
   case displayOptions
+  case done
   /// Unfortunately there's no data available for the selected date.
   case endOfData
   /// No data
@@ -143,6 +144,8 @@ extension L10n: CustomStringConvertible {
         return L10n.tr(key: "CLOSED")
       case .displayOptions:
         return L10n.tr(key: "DISPLAY_OPTIONS")
+      case .done:
+        return L10n.tr(key: "DONE")
       case .endOfData:
         return L10n.tr(key: "END_OF_DATA")
       case .endOfDataTitle:

--- a/ParkenDD/Supporting Files/Loc.swift
+++ b/ParkenDD/Supporting Files/Loc.swift
@@ -23,7 +23,7 @@ enum L10n {
   case closed
   /// Display
   case displayOptions
-  case done
+  case back
   /// Unfortunately there's no data available for the selected date.
   case endOfData
   /// No data
@@ -144,8 +144,8 @@ extension L10n: CustomStringConvertible {
         return L10n.tr(key: "CLOSED")
       case .displayOptions:
         return L10n.tr(key: "DISPLAY_OPTIONS")
-      case .done:
-        return L10n.tr(key: "DONE")
+      case .back:
+        return L10n.tr(key: "BACK")
       case .endOfData:
         return L10n.tr(key: "END_OF_DATA")
       case .endOfDataTitle:

--- a/ParkenDD/Supporting Files/Loc.swift
+++ b/ParkenDD/Supporting Files/Loc.swift
@@ -23,6 +23,7 @@ enum L10n {
   case closed
   /// Display
   case displayOptions
+  /// Back
   case back
   /// Unfortunately there's no data available for the selected date.
   case endOfData

--- a/ParkenDD/Supporting Files/Loc.swift
+++ b/ParkenDD/Supporting Files/Loc.swift
@@ -7,251 +7,251 @@ import Foundation
 
 // swiftlint:disable type_body_length
 enum L10n {
-  /// About
-  case aboutButton
-  /// Activate
-  case activate
-  /// dresden, parking, car, driving, navigation, park, public, parkinglot, lot
-  case appstoreTags
-  /// Cancel
-  case cancel
-  /// ca. %@ spots available
-  case circaSpotsAvailable(String)
-  /// City
-  case cityOptions
-  /// closed
-  case closed
-  /// Display
-  case displayOptions
-  /// Back
-  case back
-  /// Unfortunately there's no data available for the selected date.
-  case endOfData
-  /// No data
-  case endOfDataTitle
-  /// Forecast
-  case forecast
-  /// Use this function to view into the future. Pick a date and see how many spaces will presumably be available at that point in time.\n\nThe chart shows the selected day.
-  case forecastInfoText
-  /// Forecast Data
-  case forecastInfoTitle
-  /// Forecast for %@
-  case forecastTitle(String)
-  /// Hide Lots Without Data
-  case hideNodataLots
-  /// Last update:
-  case lastUpdate
-  /// Updated: %@
-  case lastUpdated(String)
-  /// List will be updated on next refresh.
-  case listUpdateOnRefresh
-  /// Load in %%
-  case loadInPercent
-  /// ParkenDD is unable to get location data. Please allow it to do so in the system settings.
-  case locationDataError
-  /// Location Data Error
-  case locationDataErrorTitle
-  /// %@ of %d available
-  case mapsubtitle(String, Int)
-  /// Unfortunately there don't seem to be any coordinates associated with this parking lot.
-  case noCoordsWarning
-  /// No coordinates
-  case noCoordsWarningTitle
-  /// Note
-  case noteTitle
-  /// Used to show location on map and for sorting parking lots by distance.
-  case nsLocationWhenInUseUsageDescription
-  /// occupied
-  case occupied
-  /// Other
-  case otherOptions
-  /// The data might be outdated. It was last updated more than an hour ago.
-  case outdatedDataWarning
-  /// Outdated data
-  case outdatedDataWarningTitle
-  /// Couldn't fetch data. You appear to be disconnected from the internet.
-  case requestError
-  /// Connection Error
-  case requestErrorTitle
-  /// Suggest a new city
-  case requestNewCity
-  /// Reset Notifications
-  case resetNotifications
-  /// Feedback / Report Problem
-  case sendFeedback
-  /// Couldn't read data from server. Please try again in a few moments.
-  case serverError
-  /// Server Error
-  case serverErrorTitle
-  /// Settings
-  case settings
-  /// Share on Twitter
-  case shareOnTwitter
-  /// The newly displayed cities are in an experimental state! Their data will probably be littered with errors and be incomplete. \n\nIf you're willing to join us in our effort of supporting new cities, please tap the feedback button below :)
-  case showexperimentalcitiesalert
-  /// Show Experimental Cities
-  case showexperimentalcitiessetting
-  /// Sort by
-  case sortingOptions
-  /// Alphabetical
-  case sortingtypeAlphabetical
-  /// Default
-  case sortingtypeDefault
-  /// Best first
-  case sortingtypeEuklid
-  /// Free Spots
-  case sortingtypeFreespots
-  /// Distance
-  case sortingtypeLocation
-  /// No free parking space in sight? → #ParkenDD http://parkendd.de
-  case tweetText
-  /// unknown address
-  case unknownAddress
-  /// Couldn't find coordinates for selected parking lot. 
-  case unknownCoordinatesError
-  /// Error
-  case unknownCoordinatesTitle
-  /// An unknown error has occurred.
-  case unknownError
-  /// Unknown error
-  case unknownErrorTitle
-  /// no data available
-  case unknownLoad
-  /// Use Grayscale Colorscheme
-  case useGrayscaleColors
-  /// waiting for location
-  case waitingForLocation
+	/// About
+	case aboutButton
+	/// Activate
+	case activate
+	/// dresden, parking, car, driving, navigation, park, public, parkinglot, lot
+	case appstoreTags
+	/// Cancel
+	case cancel
+	/// ca. %@ spots available
+	case circaSpotsAvailable(String)
+	/// City
+	case cityOptions
+	/// closed
+	case closed
+	/// Display
+	case displayOptions
+	/// Back
+	case back
+	/// Unfortunately there's no data available for the selected date.
+	case endOfData
+	/// No data
+	case endOfDataTitle
+	/// Forecast
+	case forecast
+	/// Use this function to view into the future. Pick a date and see how many spaces will presumably be available at that point in time.\n\nThe chart shows the selected day.
+	case forecastInfoText
+	/// Forecast Data
+	case forecastInfoTitle
+	/// Forecast for %@
+	case forecastTitle(String)
+	/// Hide Lots Without Data
+	case hideNodataLots
+	/// Last update:
+	case lastUpdate
+	/// Updated: %@
+	case lastUpdated(String)
+	/// List will be updated on next refresh.
+	case listUpdateOnRefresh
+	/// Load in %%
+	case loadInPercent
+	/// ParkenDD is unable to get location data. Please allow it to do so in the system settings.
+	case locationDataError
+	/// Location Data Error
+	case locationDataErrorTitle
+	/// %@ of %d available
+	case mapsubtitle(String, Int)
+	/// Unfortunately there don't seem to be any coordinates associated with this parking lot.
+	case noCoordsWarning
+	/// No coordinates
+	case noCoordsWarningTitle
+	/// Note
+	case noteTitle
+	/// Used to show location on map and for sorting parking lots by distance.
+	case nsLocationWhenInUseUsageDescription
+	/// occupied
+	case occupied
+	/// Other
+	case otherOptions
+	/// The data might be outdated. It was last updated more than an hour ago.
+	case outdatedDataWarning
+	/// Outdated data
+	case outdatedDataWarningTitle
+	/// Couldn't fetch data. You appear to be disconnected from the internet.
+	case requestError
+	/// Connection Error
+	case requestErrorTitle
+	/// Suggest a new city
+	case requestNewCity
+	/// Reset Notifications
+	case resetNotifications
+	/// Feedback / Report Problem
+	case sendFeedback
+	/// Couldn't read data from server. Please try again in a few moments.
+	case serverError
+	/// Server Error
+	case serverErrorTitle
+	/// Settings
+	case settings
+	/// Share on Twitter
+	case shareOnTwitter
+	/// The newly displayed cities are in an experimental state! Their data will probably be littered with errors and be incomplete. \n\nIf you're willing to join us in our effort of supporting new cities, please tap the feedback button below :)
+	case showexperimentalcitiesalert
+	/// Show Experimental Cities
+	case showexperimentalcitiessetting
+	/// Sort by
+	case sortingOptions
+	/// Alphabetical
+	case sortingtypeAlphabetical
+	/// Default
+	case sortingtypeDefault
+	/// Best first
+	case sortingtypeEuklid
+	/// Free Spots
+	case sortingtypeFreespots
+	/// Distance
+	case sortingtypeLocation
+	/// No free parking space in sight? → #ParkenDD http://parkendd.de
+	case tweetText
+	/// unknown address
+	case unknownAddress
+	/// Couldn't find coordinates for selected parking lot.
+	case unknownCoordinatesError
+	/// Error
+	case unknownCoordinatesTitle
+	/// An unknown error has occurred.
+	case unknownError
+	/// Unknown error
+	case unknownErrorTitle
+	/// no data available
+	case unknownLoad
+	/// Use Grayscale Colorscheme
+	case useGrayscaleColors
+	/// waiting for location
+	case waitingForLocation
 }
 // swiftlint:enable type_body_length
 
 extension L10n: CustomStringConvertible {
-  var description: String { return self.string }
+	var description: String { return self.string }
 
-  var string: String {
-    switch self {
-      case .aboutButton:
-        return L10n.tr(key: "ABOUT_BUTTON")
-      case .activate:
-        return L10n.tr(key: "ACTIVATE")
-      case .appstoreTags:
-        return L10n.tr(key: "APPSTORE_TAGS")
-      case .cancel:
-        return L10n.tr(key: "CANCEL")
-      case .circaSpotsAvailable(let p0):
-        return L10n.tr(key: "CIRCA_SPOTS_AVAILABLE", p0)
-      case .cityOptions:
-        return L10n.tr(key: "CITY_OPTIONS")
-      case .closed:
-        return L10n.tr(key: "CLOSED")
-      case .displayOptions:
-        return L10n.tr(key: "DISPLAY_OPTIONS")
-      case .back:
-        return L10n.tr(key: "BACK")
-      case .endOfData:
-        return L10n.tr(key: "END_OF_DATA")
-      case .endOfDataTitle:
-        return L10n.tr(key: "END_OF_DATA_TITLE")
-      case .forecast:
-        return L10n.tr(key: "FORECAST")
-      case .forecastInfoText:
-        return L10n.tr(key: "FORECAST_INFO_TEXT")
-      case .forecastInfoTitle:
-        return L10n.tr(key: "FORECAST_INFO_TITLE")
-      case .forecastTitle(let p0):
-        return L10n.tr(key: "FORECAST_TITLE", p0)
-      case .hideNodataLots:
-        return L10n.tr(key: "HIDE_NODATA_LOTS")
-      case .lastUpdate:
-        return L10n.tr(key: "LAST_UPDATE")
-      case .lastUpdated(let p0):
-        return L10n.tr(key: "LAST_UPDATED", p0)
-      case .listUpdateOnRefresh:
-        return L10n.tr(key: "LIST_UPDATE_ON_REFRESH")
-      case .loadInPercent:
-        return L10n.tr(key: "LOAD_IN_PERCENT")
-      case .locationDataError:
-        return L10n.tr(key: "LOCATION_DATA_ERROR")
-      case .locationDataErrorTitle:
-        return L10n.tr(key: "LOCATION_DATA_ERROR_TITLE")
-      case .mapsubtitle(let p0, let p1):
-        return L10n.tr(key: "MAPSUBTITLE", p0, p1)
-      case .noCoordsWarning:
-        return L10n.tr(key: "NO_COORDS_WARNING")
-      case .noCoordsWarningTitle:
-        return L10n.tr(key: "NO_COORDS_WARNING_TITLE")
-      case .noteTitle:
-        return L10n.tr(key: "NOTE_TITLE")
-      case .nsLocationWhenInUseUsageDescription:
-        return L10n.tr(key: "NSLocationWhenInUseUsageDescription")
-      case .occupied:
-        return L10n.tr(key: "OCCUPIED")
-      case .otherOptions:
-        return L10n.tr(key: "OTHER_OPTIONS")
-      case .outdatedDataWarning:
-        return L10n.tr(key: "OUTDATED_DATA_WARNING")
-      case .outdatedDataWarningTitle:
-        return L10n.tr(key: "OUTDATED_DATA_WARNING_TITLE")
-      case .requestError:
-        return L10n.tr(key: "REQUEST_ERROR")
-      case .requestErrorTitle:
-        return L10n.tr(key: "REQUEST_ERROR_TITLE")
-      case .requestNewCity:
-        return L10n.tr(key: "REQUEST_NEW_CITY")
-      case .resetNotifications:
-        return L10n.tr(key: "RESET_NOTIFICATIONS")
-      case .sendFeedback:
-        return L10n.tr(key: "SEND_FEEDBACK")
-      case .serverError:
-        return L10n.tr(key: "SERVER_ERROR")
-      case .serverErrorTitle:
-        return L10n.tr(key: "SERVER_ERROR_TITLE")
-      case .settings:
-        return L10n.tr(key: "SETTINGS")
-      case .shareOnTwitter:
-        return L10n.tr(key: "SHARE_ON_TWITTER")
-      case .showexperimentalcitiesalert:
-        return L10n.tr(key: "SHOWEXPERIMENTALCITIESALERT")
-      case .showexperimentalcitiessetting:
-        return L10n.tr(key: "SHOWEXPERIMENTALCITIESSETTING")
-      case .sortingOptions:
-        return L10n.tr(key: "SORTING_OPTIONS")
-      case .sortingtypeAlphabetical:
-        return L10n.tr(key: "SORTINGTYPE_ALPHABETICAL")
-      case .sortingtypeDefault:
-        return L10n.tr(key: "SORTINGTYPE_DEFAULT")
-      case .sortingtypeEuklid:
-        return L10n.tr(key: "SORTINGTYPE_EUKLID")
-      case .sortingtypeFreespots:
-        return L10n.tr(key: "SORTINGTYPE_FREESPOTS")
-      case .sortingtypeLocation:
-        return L10n.tr(key: "SORTINGTYPE_LOCATION")
-      case .tweetText:
-        return L10n.tr(key: "TWEET_TEXT")
-      case .unknownAddress:
-        return L10n.tr(key: "UNKNOWN_ADDRESS")
-      case .unknownCoordinatesError:
-        return L10n.tr(key: "UNKNOWN_COORDINATES_ERROR")
-      case .unknownCoordinatesTitle:
-        return L10n.tr(key: "UNKNOWN_COORDINATES_TITLE")
-      case .unknownError:
-        return L10n.tr(key: "UNKNOWN_ERROR")
-      case .unknownErrorTitle:
-        return L10n.tr(key: "UNKNOWN_ERROR_TITLE")
-      case .unknownLoad:
-        return L10n.tr(key: "UNKNOWN_LOAD")
-      case .useGrayscaleColors:
-        return L10n.tr(key: "USE_GRAYSCALE_COLORS")
-      case .waitingForLocation:
-        return L10n.tr(key: "WAITING_FOR_LOCATION")
-    }
-  }
+	var string: String {
+		switch self {
+		case .aboutButton:
+			return L10n.tr(key: "ABOUT_BUTTON")
+		case .activate:
+			return L10n.tr(key: "ACTIVATE")
+		case .appstoreTags:
+			return L10n.tr(key: "APPSTORE_TAGS")
+		case .cancel:
+			return L10n.tr(key: "CANCEL")
+		case .circaSpotsAvailable(let p0):
+			return L10n.tr(key: "CIRCA_SPOTS_AVAILABLE", p0)
+		case .cityOptions:
+			return L10n.tr(key: "CITY_OPTIONS")
+		case .closed:
+			return L10n.tr(key: "CLOSED")
+		case .displayOptions:
+			return L10n.tr(key: "DISPLAY_OPTIONS")
+		case .back:
+			return L10n.tr(key: "BACK")
+		case .endOfData:
+			return L10n.tr(key: "END_OF_DATA")
+		case .endOfDataTitle:
+			return L10n.tr(key: "END_OF_DATA_TITLE")
+		case .forecast:
+			return L10n.tr(key: "FORECAST")
+		case .forecastInfoText:
+			return L10n.tr(key: "FORECAST_INFO_TEXT")
+		case .forecastInfoTitle:
+			return L10n.tr(key: "FORECAST_INFO_TITLE")
+		case .forecastTitle(let p0):
+			return L10n.tr(key: "FORECAST_TITLE", p0)
+		case .hideNodataLots:
+			return L10n.tr(key: "HIDE_NODATA_LOTS")
+		case .lastUpdate:
+			return L10n.tr(key: "LAST_UPDATE")
+		case .lastUpdated(let p0):
+			return L10n.tr(key: "LAST_UPDATED", p0)
+		case .listUpdateOnRefresh:
+			return L10n.tr(key: "LIST_UPDATE_ON_REFRESH")
+		case .loadInPercent:
+			return L10n.tr(key: "LOAD_IN_PERCENT")
+		case .locationDataError:
+			return L10n.tr(key: "LOCATION_DATA_ERROR")
+		case .locationDataErrorTitle:
+			return L10n.tr(key: "LOCATION_DATA_ERROR_TITLE")
+		case .mapsubtitle(let p0, let p1):
+			return L10n.tr(key: "MAPSUBTITLE", p0, p1)
+		case .noCoordsWarning:
+			return L10n.tr(key: "NO_COORDS_WARNING")
+		case .noCoordsWarningTitle:
+			return L10n.tr(key: "NO_COORDS_WARNING_TITLE")
+		case .noteTitle:
+			return L10n.tr(key: "NOTE_TITLE")
+		case .nsLocationWhenInUseUsageDescription:
+			return L10n.tr(key: "NSLocationWhenInUseUsageDescription")
+		case .occupied:
+			return L10n.tr(key: "OCCUPIED")
+		case .otherOptions:
+			return L10n.tr(key: "OTHER_OPTIONS")
+		case .outdatedDataWarning:
+			return L10n.tr(key: "OUTDATED_DATA_WARNING")
+		case .outdatedDataWarningTitle:
+			return L10n.tr(key: "OUTDATED_DATA_WARNING_TITLE")
+		case .requestError:
+			return L10n.tr(key: "REQUEST_ERROR")
+		case .requestErrorTitle:
+			return L10n.tr(key: "REQUEST_ERROR_TITLE")
+		case .requestNewCity:
+			return L10n.tr(key: "REQUEST_NEW_CITY")
+		case .resetNotifications:
+			return L10n.tr(key: "RESET_NOTIFICATIONS")
+		case .sendFeedback:
+			return L10n.tr(key: "SEND_FEEDBACK")
+		case .serverError:
+			return L10n.tr(key: "SERVER_ERROR")
+		case .serverErrorTitle:
+			return L10n.tr(key: "SERVER_ERROR_TITLE")
+		case .settings:
+			return L10n.tr(key: "SETTINGS")
+		case .shareOnTwitter:
+			return L10n.tr(key: "SHARE_ON_TWITTER")
+		case .showexperimentalcitiesalert:
+			return L10n.tr(key: "SHOWEXPERIMENTALCITIESALERT")
+		case .showexperimentalcitiessetting:
+			return L10n.tr(key: "SHOWEXPERIMENTALCITIESSETTING")
+		case .sortingOptions:
+			return L10n.tr(key: "SORTING_OPTIONS")
+		case .sortingtypeAlphabetical:
+			return L10n.tr(key: "SORTINGTYPE_ALPHABETICAL")
+		case .sortingtypeDefault:
+			return L10n.tr(key: "SORTINGTYPE_DEFAULT")
+		case .sortingtypeEuklid:
+			return L10n.tr(key: "SORTINGTYPE_EUKLID")
+		case .sortingtypeFreespots:
+			return L10n.tr(key: "SORTINGTYPE_FREESPOTS")
+		case .sortingtypeLocation:
+			return L10n.tr(key: "SORTINGTYPE_LOCATION")
+		case .tweetText:
+			return L10n.tr(key: "TWEET_TEXT")
+		case .unknownAddress:
+			return L10n.tr(key: "UNKNOWN_ADDRESS")
+		case .unknownCoordinatesError:
+			return L10n.tr(key: "UNKNOWN_COORDINATES_ERROR")
+		case .unknownCoordinatesTitle:
+			return L10n.tr(key: "UNKNOWN_COORDINATES_TITLE")
+		case .unknownError:
+			return L10n.tr(key: "UNKNOWN_ERROR")
+		case .unknownErrorTitle:
+			return L10n.tr(key: "UNKNOWN_ERROR_TITLE")
+		case .unknownLoad:
+			return L10n.tr(key: "UNKNOWN_LOAD")
+		case .useGrayscaleColors:
+			return L10n.tr(key: "USE_GRAYSCALE_COLORS")
+		case .waitingForLocation:
+			return L10n.tr(key: "WAITING_FOR_LOCATION")
+		}
+	}
 
-  private static func tr(key: String, _ args: CVarArg...) -> String {
-    let format = NSLocalizedString(key, comment: "")
-    return String(format: format, locale: Locale.current, arguments: args)
-  }
+	private static func tr(key: String, _ args: CVarArg...) -> String {
+		let format = NSLocalizedString(key, comment: "")
+		return String(format: format, locale: Locale.current, arguments: args)
+	}
 }
 
 func tr(_ key: L10n) -> String {
-  return key.string
+	return key.string
 }

--- a/ParkenDD/Supporting Files/cs.lproj/Localizable.strings
+++ b/ParkenDD/Supporting Files/cs.lproj/Localizable.strings
@@ -27,6 +27,7 @@
 "LOCATION_DATA_ERROR" = "ParkenDD se nepovedlo získat aktuální pozici. Prosím, povolte tuto funkci v systémových nastaveních.";
 "CANCEL" = "Storno";
 "SETTINGS" = "Nastavení";
+"BACK" = "Dozadu";
 "CIRCA_SPOTS_AVAILABLE" = "Zhruba %@ míst volných";
 "DISPLAY_OPTIONS" = "Zobrazení";
 "HIDE_NODATA_LOTS" = "Skrýt parkoviště bez dostupných dat";

--- a/ParkenDD/Supporting Files/de.lproj/Localizable.strings
+++ b/ParkenDD/Supporting Files/de.lproj/Localizable.strings
@@ -27,6 +27,7 @@
 "LOCATION_DATA_ERROR" = "ParkenDD hat keine Berechtigung sich zu lokalisieren. Bitte erlaube das in den Einstellungen.";
 "CANCEL" = "Abbrechen";
 "SETTINGS" = "Einstellungen";
+"DONE" = "Zurück";
 "CIRCA_SPOTS_AVAILABLE" = "ca. %@ freie Plätze";
 "DISPLAY_OPTIONS" = "Darstellung";
 "HIDE_NODATA_LOTS" = "Parkplätze ohne Daten ausblenden";

--- a/ParkenDD/Supporting Files/de.lproj/Localizable.strings
+++ b/ParkenDD/Supporting Files/de.lproj/Localizable.strings
@@ -27,7 +27,7 @@
 "LOCATION_DATA_ERROR" = "ParkenDD hat keine Berechtigung sich zu lokalisieren. Bitte erlaube das in den Einstellungen.";
 "CANCEL" = "Abbrechen";
 "SETTINGS" = "Einstellungen";
-"DONE" = "Zurück";
+"BACK" = "Zurück";
 "CIRCA_SPOTS_AVAILABLE" = "ca. %@ freie Plätze";
 "DISPLAY_OPTIONS" = "Darstellung";
 "HIDE_NODATA_LOTS" = "Parkplätze ohne Daten ausblenden";

--- a/ParkenDD/Supporting Files/pl.lproj/Localizable.strings
+++ b/ParkenDD/Supporting Files/pl.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-﻿"REQUEST_ERROR_TITLE" = "Błąd połączenia";
+"REQUEST_ERROR_TITLE" = "Błąd połączenia";
 "REQUEST_ERROR" = "Nie można załadować danych. Prawdopodobnie nie ma połączenia internetowego.";
 "SERVER_ERROR_TITLE" = "Błąd serweru";
 "SERVER_ERROR" = "Nie można odczytać danych. Prosze zaktualizuj za chwilę ponownie.";
@@ -28,6 +28,7 @@
 "LOCATION_DATA_ERROR" = "ParkenDD nie ma zezwolenia do lokalizacji. \nProsze dostępnij to w ustawieniach.";
 "CANCEL" = "Anuluj";
 "SETTINGS" = "Ustawienia";
+"BACK" = "Wstecz";
 "CIRCA_SPOTS_AVAILABLE" = "ca. %@ miejsca wolne";
 "DISPLAY_OPTIONS" = "Opcje wyświetlania";
 "HIDE_NODATA_LOTS" = "Ukryć parkingi bez danych";


### PR DESCRIPTION
When in the city selection screen, tapping on the "back" button would cause the label to disappear but the app did not navigate back to the previous screen. The user was forced to tap on the back arrow instead of the label.  I fixed this issue by setting the back button text to an option provided by the language translation enum.  I also needed to add a translation for "BACK".